### PR TITLE
Add decorative corner and side images

### DIFF
--- a/apoio.html
+++ b/apoio.html
@@ -29,12 +29,12 @@
 
     <main>
         <div class="page-decorations">
-            <div class="corner-decoration top-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration top-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="side-decoration left"><img src="images/corner2.png" alt="" /></div>
-            <div class="side-decoration right"><img src="images/corner2.png" alt="" /></div>
+            <div class="corner-decoration top-left"></div>
+            <div class="corner-decoration top-right"></div>
+            <div class="corner-decoration bottom-left"></div>
+            <div class="corner-decoration bottom-right"></div>
+            <div class="side-decoration left"></div>
+            <div class="side-decoration right"></div>
         </div>
         <section>
             <h2>Como Apoiar</h2>

--- a/beneficios.html
+++ b/beneficios.html
@@ -29,12 +29,12 @@
 
     <main>
         <div class="page-decorations">
-            <div class="corner-decoration top-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration top-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="side-decoration left"><img src="images/corner2.png" alt="" /></div>
-            <div class="side-decoration right"><img src="images/corner2.png" alt="" /></div>
+            <div class="corner-decoration top-left"></div>
+            <div class="corner-decoration top-right"></div>
+            <div class="corner-decoration bottom-left"></div>
+            <div class="corner-decoration bottom-right"></div>
+            <div class="side-decoration left"></div>
+            <div class="side-decoration right"></div>
         </div>
         <section>
             <h2>Edital de Participação</h2>

--- a/contato.html
+++ b/contato.html
@@ -28,12 +28,12 @@
 
     <main>
         <div class="page-decorations">
-            <div class="corner-decoration top-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration top-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="side-decoration left"><img src="images/corner2.png" alt="" /></div>
-            <div class="side-decoration right"><img src="images/corner2.png" alt="" /></div>
+            <div class="corner-decoration top-left"></div>
+            <div class="corner-decoration top-right"></div>
+            <div class="corner-decoration bottom-left"></div>
+            <div class="corner-decoration bottom-right"></div>
+            <div class="side-decoration left"></div>
+            <div class="side-decoration right"></div>
         </div>
         <section>
             <h2>Entre em Contato</h2>

--- a/edicoes.html
+++ b/edicoes.html
@@ -29,12 +29,12 @@
 
     <main>
         <div class="page-decorations">
-            <div class="corner-decoration top-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration top-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="side-decoration left"><img src="images/corner2.png" alt="" /></div>
-            <div class="side-decoration right"><img src="images/corner2.png" alt="" /></div>
+            <div class="corner-decoration top-left"></div>
+            <div class="corner-decoration top-right"></div>
+            <div class="corner-decoration bottom-left"></div>
+            <div class="corner-decoration bottom-right"></div>
+            <div class="side-decoration left"></div>
+            <div class="side-decoration right"></div>
         </div>
         <section>
             <h2>Edições Passadas</h1>

--- a/edital.html
+++ b/edital.html
@@ -29,12 +29,12 @@
 
     <main>
         <div class="page-decorations">
-            <div class="corner-decoration top-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration top-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="side-decoration left"><img src="images/corner2.png" alt="" /></div>
-            <div class="side-decoration right"><img src="images/corner2.png" alt="" /></div>
+            <div class="corner-decoration top-left"></div>
+            <div class="corner-decoration top-right"></div>
+            <div class="corner-decoration bottom-left"></div>
+            <div class="corner-decoration bottom-right"></div>
+            <div class="side-decoration left"></div>
+            <div class="side-decoration right"></div>
         </div>
         <section>
             <h2 id="edital">Edital de Participação</h2>

--- a/index.html
+++ b/index.html
@@ -29,12 +29,12 @@
 
     <main>
         <div class="page-decorations">
-            <div class="corner-decoration top-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration top-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="side-decoration left"><img src="images/corner2.png" alt="" /></div>
-            <div class="side-decoration right"><img src="images/corner2.png" alt="" /></div>
+            <div class="corner-decoration top-left"></div>
+            <div class="corner-decoration top-right"></div>
+            <div class="corner-decoration bottom-left"></div>
+            <div class="corner-decoration bottom-right"></div>
+            <div class="side-decoration left"></div>
+            <div class="side-decoration right"></div>
         </div>
         <section>
             <h1>Transformando Escolas Públicas com Robótica</h1>

--- a/organizadores.html
+++ b/organizadores.html
@@ -29,12 +29,12 @@
 
     <main>
         <div class="page-decorations">
-            <div class="corner-decoration top-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration top-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-left"><img src="images/corner1.png" alt="" /></div>
-            <div class="corner-decoration bottom-right"><img src="images/corner1.png" alt="" /></div>
-            <div class="side-decoration left"><img src="images/corner2.png" alt="" /></div>
-            <div class="side-decoration right"><img src="images/corner2.png" alt="" /></div>
+            <div class="corner-decoration top-left"></div>
+            <div class="corner-decoration top-right"></div>
+            <div class="corner-decoration bottom-left"></div>
+            <div class="corner-decoration bottom-right"></div>
+            <div class="side-decoration left"></div>
+            <div class="side-decoration right"></div>
         </div>
         <section>
             <h2>Organizadores e Parceiros</h2>

--- a/style.css
+++ b/style.css
@@ -311,86 +311,71 @@ section {
 
 main {
     position: relative;
+    background: #fff;
+    overflow: visible;
 }
 
 .page-decorations {
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
 }
 
 .corner-decoration,
 .side-decoration {
     position: absolute;
-    z-index: -1;
-    pointer-events: none;
-    overflow: hidden;
+    background-repeat: no-repeat;
 }
 
+/* corner accents */
 .corner-decoration {
-    width: 150px;
-    height: 150px;
-}
-
-.corner-decoration img {
-    width: 300px;
-    height: 300px;
+    width: 165px;
+    height: 165px;
+    background-image: url(images/corner3.png);
+    background-size: 329px 329px;
 }
 
 .corner-decoration.top-left {
-    top: 0;
-    left: 0;
+    top: -82px;
+    left: -82px;
+    background-position: left top;
 }
 
 .corner-decoration.top-right {
-    top: 0;
-    right: 0;
+    top: -82px;
+    right: -82px;
+    background-position: right top;
 }
 
 .corner-decoration.bottom-left {
-    bottom: 0;
-    left: 0;
+    bottom: -82px;
+    left: -82px;
+    background-position: left bottom;
 }
 
 .corner-decoration.bottom-right {
-    bottom: 0;
-    right: 0;
+    bottom: -82px;
+    right: -82px;
+    background-position: right bottom;
 }
 
-.corner-decoration.top-right img {
-    transform: translateX(-150px);
-}
-
-.corner-decoration.bottom-left img {
-    transform: translateY(-150px);
-}
-
-.corner-decoration.bottom-right img {
-    transform: translate(-150px, -150px);
-}
-
+/* side accents */
 .side-decoration {
+    width: 186px;
+    height: 373px;
     top: 50%;
-    width: 150px;
-    height: 300px;
     transform: translateY(-50%);
-}
-
-.side-decoration img {
-    width: 300px;
-    height: 300px;
+    background-image: url(images/corner5.png);
+    background-size: 372px 373px;
 }
 
 .side-decoration.left {
-    left: 0;
+    left: -93px;
+    background-position: left center;
 }
 
 .side-decoration.right {
-    right: 0;
-}
-
-.side-decoration.right img {
-    transform: translateX(-150px);
+    right: -93px;
+    background-position: right center;
 }


### PR DESCRIPTION
## Summary
- add fixed-position corner and side decorations using cropped circular images
- include decoration markup on each page for consistent branding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ef329a2c8321a4f6e27f85b2114f