### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/apoio.html
+++ b/apoio.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Robôs Que Transformam</title>
     <link rel="stylesheet" href="style.css" />
 </head>

--- a/contato.html
+++ b/contato.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Contato - Robôs Que Transformam</title>
     <link rel="stylesheet" href="style.css" />
 </head>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Robôs Que Transformam</title>
     <link rel="stylesheet" href="style.css" />
 </head>

--- a/organizadores.html
+++ b/organizadores.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Robôs Que Transformam</title>
     <link rel="stylesheet" href="style.css" />
 </head>

--- a/style.css
+++ b/style.css
@@ -218,14 +218,16 @@ html {
 
 .sponsors {
     display: flex;
-    align-items: stretch;
-    gap: 20px;
-    height: 60px;
+    align-items: center;
+    gap: clamp(12px, 2vw, 24px);
 }
 
 .sponsor-logo {
-    height: 100%;
+    height: auto;
     width: auto;
+    max-width: 100%;
+    max-height: clamp(30px, 8vw, 60px);
+    object-fit: contain;
 }
 
 .sponsor-separator {
@@ -518,5 +520,28 @@ main {
 
     to {
         opacity: 1
+    }
+}
+
+@media (max-width: 600px) {
+    #hero .hero-navigation ul {
+        flex-direction: column;
+        align-items: center;
+        font-size: 4.5vw;
+        gap: 10px;
+    }
+
+    #hero .hero-navigation li::after {
+        display: none;
+    }
+
+    .sponsors {
+        flex-direction: column;
+        height: auto;
+        gap: 10px;
+    }
+
+    .page-decorations {
+        display: none;
     }
 }

--- a/style.css
+++ b/style.css
@@ -536,16 +536,20 @@ main {
     }
 
     .footer {
-        flex-direction: column;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
         align-items: center;
         text-align: center;
+        gap: 10px;
     }
 
     .footer p {
-        font-size: 3.5vw;
+        font-size: 3vw;
     }
 
     .footer .sponsors {
+        margin-left: 0;
         flex-wrap: wrap;
         justify-content: center;
         gap: 10px;

--- a/style.css
+++ b/style.css
@@ -535,9 +535,19 @@ main {
         display: none;
     }
 
-    .sponsors {
+    .footer {
         flex-direction: column;
-        height: auto;
+        align-items: center;
+        text-align: center;
+    }
+
+    .footer p {
+        font-size: 3.5vw;
+    }
+
+    .footer .sponsors {
+        flex-wrap: wrap;
+        justify-content: center;
         gap: 10px;
     }
 


### PR DESCRIPTION
## Summary
- Add viewport meta tag to all HTML pages for proper scaling on phones
- Introduce mobile layout tweaks for navigation, sponsor logos, and decorations
- Make footer sponsor logos responsive to scale on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8799a39c832188154e6adc2ebbd4